### PR TITLE
Start versioning the gurobi casks

### DIFF
--- a/Casks/gurobi80.rb
+++ b/Casks/gurobi80.rb
@@ -36,7 +36,14 @@ cask "gurobi80" do
   desc "Mathematical programming solver for LP, QP, and MIP problems"
   homepage "https://www.gurobi.com/products/gurobi-optimizer"
 
-  conflicts_with cask: "gurobi"
+  # NOTE: conflict with all possible versions of this cask from drake (see note
+  # below about uninstall files).
+  conflicts_with cask: [
+    "gurobi",
+    # "gurobi80",  # This cask.
+    "gurobi@9.5.2",
+    "gurobi@10.0.2",
+  ]
 
   pkg "gurobi#{version}_mac64.pkg"
 
@@ -44,8 +51,10 @@ cask "gurobi80" do
             delete:  [
               "/Applications/Gurobi #{version}.app",
               "/Library/gurobi#{version.no_dots}",
-              "/Library/Java/Extensions/gurobi.jar",
               "/Library/Java/Extensions/libGurobiJni#{version.major_minor.no_dots}.jnilib",
+              # NOTE: these are symlinks and may point to a different gurobi,
+              # make sure you `conflicts_with` correctly above.
+              "/Library/Java/Extensions/gurobi.jar",
               "/usr/local/bin/grb_ts",
               "/usr/local/bin/grbcluster",
               "/usr/local/bin/grbgetkey",

--- a/Casks/gurobi@10.0.2.rb
+++ b/Casks/gurobi@10.0.2.rb
@@ -1,5 +1,5 @@
-# Copyright (c) 2019, Massachusetts Institute of Technology.
-# Copyright (c) 2019, Toyota Research Institute.
+# Copyright (c) 2023, Massachusetts Institute of Technology.
+# Copyright (c) 2023, Toyota Research Institute.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,27 +27,25 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cask "gurobi" do
-  version "9.5.2"
-  sha256 "e183ca8bcf3950d16e282dc7ffadfbada29240e7be60331865279b580fad08f6"
+cask "gurobi@10.0.2" do
+  version "10.0.2"
 
-  url "https://packages.gurobi.com/#{version.major_minor}/gurobi#{version}_macos_universal2.pkg"
-  appcast "https://www.gurobi.com/resource/fixes/"
   name "Gurobi Optimizer"
   desc "Mathematical programming solver for LP, QP, and MIP problems"
   homepage "https://www.gurobi.com/products/gurobi-optimizer/"
 
+  pkg "gurobi#{version}_macos_universal2.pkg"
+  url "https://packages.gurobi.com/#{version.major_minor}/gurobi#{version}_macos_universal2.pkg"
+  sha256 "955bb1cfa9a72b09c23af6413a10e95f8e05a189539619495f123ff0f3c258c8"
+
   # NOTE: conflict with all possible versions of this cask from drake (see note
   # below about uninstall files).
   conflicts_with cask: [
-    # "gurobi",  # This cask.
+    "gurobi",
     "gurobi80",
     "gurobi@9.5.2",
-    "gurobi@10.0.2",
+    # "gurobi@10.0.2",  # This cask.
   ]
-  conflicts_with cask: "gurobi80"
-
-  pkg "gurobi#{version}_macos_universal2.pkg"
 
   uninstall pkgutil: "com.gurobi.gurobiOptimizer#{version.no_dots}.gurobimac.pkg",
             delete:  [

--- a/Casks/gurobi@9.5.2.rb
+++ b/Casks/gurobi@9.5.2.rb
@@ -1,5 +1,5 @@
-# Copyright (c) 2019, Massachusetts Institute of Technology.
-# Copyright (c) 2019, Toyota Research Institute.
+# Copyright (c) 2023, Massachusetts Institute of Technology.
+# Copyright (c) 2023, Toyota Research Institute.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,27 +27,25 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cask "gurobi" do
+cask "gurobi@9.5.2" do
   version "9.5.2"
-  sha256 "e183ca8bcf3950d16e282dc7ffadfbada29240e7be60331865279b580fad08f6"
 
-  url "https://packages.gurobi.com/#{version.major_minor}/gurobi#{version}_macos_universal2.pkg"
-  appcast "https://www.gurobi.com/resource/fixes/"
   name "Gurobi Optimizer"
   desc "Mathematical programming solver for LP, QP, and MIP problems"
   homepage "https://www.gurobi.com/products/gurobi-optimizer/"
 
+  pkg "gurobi#{version}_macos_universal2.pkg"
+  url "https://packages.gurobi.com/#{version.major_minor}/gurobi#{version}_macos_universal2.pkg"
+  sha256 "e183ca8bcf3950d16e282dc7ffadfbada29240e7be60331865279b580fad08f6"
+
   # NOTE: conflict with all possible versions of this cask from drake (see note
   # below about uninstall files).
   conflicts_with cask: [
-    # "gurobi",  # This cask.
+    "gurobi",
     "gurobi80",
-    "gurobi@9.5.2",
+    # "gurobi@9.5.2",  # This cask.
     "gurobi@10.0.2",
   ]
-  conflicts_with cask: "gurobi80"
-
-  pkg "gurobi#{version}_macos_universal2.pkg"
 
   uninstall pkgutil: "com.gurobi.gurobiOptimizer#{version.no_dots}.gurobimac.pkg",
             delete:  [


### PR DESCRIPTION
- As new versions are added, each gurobi cask should be updated to conflicts_with the new one being added.
- See uninstall, side by side installations are not supported.